### PR TITLE
Added license header in the code files as mentioned in issue #3

### DIFF
--- a/webapp/assessment/urls.py
+++ b/webapp/assessment/urls.py
@@ -1,31 +1,10 @@
 """
-Redistribution and use of the software accompanying this license in source and 
-binary forms, with or without modification, are permitted provided that the 
-following conditions are met:
-
-    1. Redistributions of source code must retain the above copyright notice, 
-	this list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright 
-	notice, this list of conditions and the following disclaimer in the 
-	documentation and/or other materials provided with the distribution.
-    3. Modifications to the source code must retain the above copyright 
-	notice, this list of conditions, and the following disclaimer, and may 
-	not include further conditions or licensing which go against the spirit 
-	of this license.
-    4. This software may not be used to cause deliberate harm to any 
-	individual, either directly or indirectly, in any form.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER, AUTHORS, OR CONTRIBUTORS BE
-LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE 
-GOODS OR SERVICES; LOSS OF USE, DATA, MONEY, POSSESSIONS, OR LIFE; OR BUSINESS 
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
-IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
-OF SUCH DAMAGE.
+Filename: assessment/urls.py 
+Authors: Bithin Alangot Seshagiri Prabhu Harish Navnit
+Copyright: Wise Earth Technology
+This file is part of the CrisisCommunicator Project.  
+It is licensed under the Peaceful Open Source License.  
+Please see the license terms in PeaceOSL.txt
 """
 from django.conf.urls.defaults import *
 

--- a/webapp/assessment/views.py
+++ b/webapp/assessment/views.py
@@ -1,31 +1,10 @@
 """
-Redistribution and use of the software accompanying this license in source and 
-binary forms, with or without modification, are permitted provided that the 
-following conditions are met:
-
-    1. Redistributions of source code must retain the above copyright notice, 
-	this list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright 
-	notice, this list of conditions and the following disclaimer in the 
-	documentation and/or other materials provided with the distribution.
-    3. Modifications to the source code must retain the above copyright 
-	notice, this list of conditions, and the following disclaimer, and may 
-	not include further conditions or licensing which go against the spirit 
-	of this license.
-    4. This software may not be used to cause deliberate harm to any 
-	individual, either directly or indirectly, in any form.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER, AUTHORS, OR CONTRIBUTORS BE
-LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE 
-GOODS OR SERVICES; LOSS OF USE, DATA, MONEY, POSSESSIONS, OR LIFE; OR BUSINESS 
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
-IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
-OF SUCH DAMAGE.
+Filename: assessment/views.py
+Authors: Bithin Alangot Seshagiri Prabhu Harish Navnit
+Copyright: Wise Earth Technology
+This file is part of the CrisisCommunicator Project.  
+It is licensed under the Peaceful Open Source License.  
+Please see the license terms in PeaceOSL.txt
 """
 from django.shortcuts import get_object_or_404, render_to_response
 from django.http import HttpResponseRedirect

--- a/webapp/communicator/forms.py
+++ b/webapp/communicator/forms.py
@@ -1,3 +1,11 @@
+"""
+Filename: communicator/forms.py
+Authors: Bithin Alangot Seshagiri Prabhu Harish Navnit
+Copyright: Wise Earth Technology
+This file is part of the CrisisCommunicator Project.  
+It is licensed under the Peaceful Open Source License.  
+Please see the license terms in PeaceOSL.txt
+"""
 from django.forms import ModelForm
 from django import forms
 #from django.core import Validator

--- a/webapp/communicator/helper.py
+++ b/webapp/communicator/helper.py
@@ -1,31 +1,10 @@
 """
-Redistribution and use of the software accompanying this license in source and 
-binary forms, with or without modification, are permitted provided that the 
-following conditions are met:
-
-    1. Redistributions of source code must retain the above copyright notice, 
-	this list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright 
-	notice, this list of conditions and the following disclaimer in the 
-	documentation and/or other materials provided with the distribution.
-    3. Modifications to the source code must retain the above copyright 
-	notice, this list of conditions, and the following disclaimer, and may 
-	not include further conditions or licensing which go against the spirit 
-	of this license.
-    4. This software may not be used to cause deliberate harm to any 
-	individual, either directly or indirectly, in any form.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER, AUTHORS, OR CONTRIBUTORS BE
-LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE 
-GOODS OR SERVICES; LOSS OF USE, DATA, MONEY, POSSESSIONS, OR LIFE; OR BUSINESS 
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
-IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
-OF SUCH DAMAGE.
+Filename: communicator/helper.py
+Authors: Bithin Alangot Seshagiri Prabhu Harish Navnit
+Copyright: Wise Earth Technology
+This file is part of the CrisisCommunicator Project.  
+It is licensed under the Peaceful Open Source License.  
+Please see the license terms in PeaceOSL.txt
 """
 from crisis.models import User
 

--- a/webapp/communicator/settings.py
+++ b/webapp/communicator/settings.py
@@ -1,3 +1,11 @@
+"""
+Filename: communicator/settings.py
+Authors: Bithin Alangot Seshagiri Prabhu Harish Navnit
+Copyright: Wise Earth Technology
+This file is part of the CrisisCommunicator Project.  
+It is licensed under the Peaceful Open Source License.  
+Please see the license terms in PeaceOSL.txt
+"""
 #Django settings for communicator project.
 import os
 

--- a/webapp/communicator/urls.py
+++ b/webapp/communicator/urls.py
@@ -1,31 +1,10 @@
 """
-Redistribution and use of the software accompanying this license in source and 
-binary forms, with or without modification, are permitted provided that the 
-following conditions are met:
-
-    1. Redistributions of source code must retain the above copyright notice, 
-	this list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright 
-	notice, this list of conditions and the following disclaimer in the 
-	documentation and/or other materials provided with the distribution.
-    3. Modifications to the source code must retain the above copyright 
-	notice, this list of conditions, and the following disclaimer, and may 
-	not include further conditions or licensing which go against the spirit 
-	of this license.
-    4. This software may not be used to cause deliberate harm to any 
-	individual, either directly or indirectly, in any form.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER, AUTHORS, OR CONTRIBUTORS BE
-LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE 
-GOODS OR SERVICES; LOSS OF USE, DATA, MONEY, POSSESSIONS, OR LIFE; OR BUSINESS 
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
-IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
-OF SUCH DAMAGE.
+Filename: communicator/urls.py
+Authors: Bithin Alangot Seshagiri Prabhu Harish Navnit
+Copyright: Wise Earth Technology
+This file is part of the CrisisCommunicator Project.  
+It is licensed under the Peaceful Open Source License.  
+Please see the license terms in PeaceOSL.txt
 """
 from django.conf.urls.defaults import *
 from communicator.views import user_home, user_register, logout

--- a/webapp/communicator/views.py
+++ b/webapp/communicator/views.py
@@ -1,31 +1,10 @@
 """
-Redistribution and use of the software accompanying this license in source and 
-binary forms, with or without modification, are permitted provided that the 
-following conditions are met:
-
-    1. Redistributions of source code must retain the above copyright notice, 
-	this list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright 
-	notice, this list of conditions and the following disclaimer in the 
-	documentation and/or other materials provided with the distribution.
-    3. Modifications to the source code must retain the above copyright 
-	notice, this list of conditions, and the following disclaimer, and may 
-	not include further conditions or licensing which go against the spirit 
-	of this license.
-    4. This software may not be used to cause deliberate harm to any 
-	individual, either directly or indirectly, in any form.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER, AUTHORS, OR CONTRIBUTORS BE
-LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE 
-GOODS OR SERVICES; LOSS OF USE, DATA, MONEY, POSSESSIONS, OR LIFE; OR BUSINESS 
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
-IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
-OF SUCH DAMAGE.
+Filename: communicator/views.py
+Authors: Bithin Alangot Seshagiri Prabhu Harish Navnit
+Copyright: Wise Earth Technology
+This file is part of the CrisisCommunicator Project.  
+It is licensed under the Peaceful Open Source License.  
+Please see the license terms in PeaceOSL.txt
 """
 from django.http import HttpResponse
 from django.http import HttpResponseRedirect

--- a/webapp/crisis/forms.py
+++ b/webapp/crisis/forms.py
@@ -1,3 +1,11 @@
+"""
+Filename: crisis/forms.py
+Authors: Bithin Alangot Seshagiri Prabhu Harish Navnit
+Copyright: Wise Earth Technology
+This file is part of the CrisisCommunicator Project.  
+It is licensed under the Peaceful Open Source License.  
+Please see the license terms in PeaceOSL.txt
+"""
 from django.forms import ModelForm
 from django import forms 
 

--- a/webapp/crisis/models.py
+++ b/webapp/crisis/models.py
@@ -1,3 +1,11 @@
+"""
+Filename: crisis/models.py
+Authors: Bithin Alangot Seshagiri Prabhu Harish Navnit
+Copyright: Wise Earth Technology
+This file is part of the CrisisCommunicator Project.  
+It is licensed under the Peaceful Open Source License.  
+Please see the license terms in PeaceOSL.txt
+"""
 from django.db import models
 #from refugeecenter.models import RefugeeCenter
 

--- a/webapp/crisis/urls.py
+++ b/webapp/crisis/urls.py
@@ -1,31 +1,10 @@
 """
-Redistribution and use of the software accompanying this license in source and 
-binary forms, with or without modification, are permitted provided that the 
-following conditions are met:
-
-    1. Redistributions of source code must retain the above copyright notice, 
-	this list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright 
-	notice, this list of conditions and the following disclaimer in the 
-	documentation and/or other materials provided with the distribution.
-    3. Modifications to the source code must retain the above copyright 
-	notice, this list of conditions, and the following disclaimer, and may 
-	not include further conditions or licensing which go against the spirit 
-	of this license.
-    4. This software may not be used to cause deliberate harm to any 
-	individual, either directly or indirectly, in any form.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER, AUTHORS, OR CONTRIBUTORS BE
-LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE 
-GOODS OR SERVICES; LOSS OF USE, DATA, MONEY, POSSESSIONS, OR LIFE; OR BUSINESS 
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
-IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
-OF SUCH DAMAGE.
+Filename: crisis/urls.py
+Authors: Bithin Alangot Seshagiri Prabhu Harish Navnit
+Copyright: Wise Earth Technology
+This file is part of the CrisisCommunicator Project.  
+It is licensed under the Peaceful Open Source License.  
+Please see the license terms in PeaceOSL.txt
 """
 from django.conf.urls.defaults import *
 

--- a/webapp/person/forms.py
+++ b/webapp/person/forms.py
@@ -1,3 +1,11 @@
+"""
+Filename: person/forms.py
+Authors: Bithin Alangot Seshagiri Prabhu Harish Navnit
+Copyright: Wise Earth Technology
+This file is part of the CrisisCommunicator Project.  
+It is licensed under the Peaceful Open Source License.  
+Please see the license terms in PeaceOSL.txt
+"""
 from django.forms import ModelForm
 from django import forms
 

--- a/webapp/person/models.py
+++ b/webapp/person/models.py
@@ -1,3 +1,11 @@
+"""
+Filename: person/models.py
+Authors: Bithin Alangot Seshagiri Prabhu Harish Navnit
+Copyright: Wise Earth Technology
+This file is part of the CrisisCommunicator Project.  
+It is licensed under the Peaceful Open Source License.  
+Please see the license terms in PeaceOSL.txt
+"""
 from django.db import models
 
 from crisis.models import Global, Comment

--- a/webapp/person/search_indexes.py
+++ b/webapp/person/search_indexes.py
@@ -1,3 +1,11 @@
+"""
+Filename: person/search_index.py
+Authors: Bithin Alangot Seshagiri Prabhu Harish Navnit
+Copyright: Wise Earth Technology
+This file is part of the CrisisCommunicator Project.  
+It is licensed under the Peaceful Open Source License.  
+Please see the license terms in PeaceOSL.txt
+"""
 import datetime
 from haystack import indexes
 from models import Person, Refugee, Deceased, Missing

--- a/webapp/person/urls.py
+++ b/webapp/person/urls.py
@@ -1,31 +1,10 @@
 """
-Redistribution and use of the software accompanying this license in source and 
-binary forms, with or without modification, are permitted provided that the 
-following conditions are met:
-
-    1. Redistributions of source code must retain the above copyright notice, 
-	this list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright 
-	notice, this list of conditions and the following disclaimer in the 
-	documentation and/or other materials provided with the distribution.
-    3. Modifications to the source code must retain the above copyright 
-	notice, this list of conditions, and the following disclaimer, and may 
-	not include further conditions or licensing which go against the spirit 
-	of this license.
-    4. This software may not be used to cause deliberate harm to any 
-	individual, either directly or indirectly, in any form.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER, AUTHORS, OR CONTRIBUTORS BE
-LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE 
-GOODS OR SERVICES; LOSS OF USE, DATA, MONEY, POSSESSIONS, OR LIFE; OR BUSINESS 
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
-IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
-OF SUCH DAMAGE.
+Filename: person/urls.py
+Authors: Bithin Alangot Seshagiri Prabhu Harish Navnit
+Copyright: Wise Earth Technology
+This file is part of the CrisisCommunicator Project.  
+It is licensed under the Peaceful Open Source License.  
+Please see the license terms in PeaceOSL.txt
 """
 from django.conf.urls.defaults import *
 

--- a/webapp/person/views.py
+++ b/webapp/person/views.py
@@ -1,31 +1,10 @@
 """
-Redistribution and use of the software accompanying this license in source and 
-binary forms, with or without modification, are permitted provided that the 
-following conditions are met:
-
-    1. Redistributions of source code must retain the above copyright notice, 
-	this list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright 
-	notice, this list of conditions and the following disclaimer in the 
-	documentation and/or other materials provided with the distribution.
-    3. Modifications to the source code must retain the above copyright 
-	notice, this list of conditions, and the following disclaimer, and may 
-	not include further conditions or licensing which go against the spirit 
-	of this license.
-    4. This software may not be used to cause deliberate harm to any 
-	individual, either directly or indirectly, in any form.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER, AUTHORS, OR CONTRIBUTORS BE
-LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE 
-GOODS OR SERVICES; LOSS OF USE, DATA, MONEY, POSSESSIONS, OR LIFE; OR BUSINESS 
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
-IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
-OF SUCH DAMAGE.
+Filename: person/views.py
+Authors: Bithin Alangot Seshagiri Prabhu Harish Navnit
+Copyright: Wise Earth Technology
+This file is part of the CrisisCommunicator Project.  
+It is licensed under the Peaceful Open Source License.  
+Please see the license terms in PeaceOSL.txt
 """
 from django.shortcuts import render_to_response, get_object_or_404
 from django.template import RequestContext

--- a/webapp/refugeecenter/forms.py
+++ b/webapp/refugeecenter/forms.py
@@ -1,3 +1,11 @@
+"""
+Filename: refugeecenter/forms.py
+Authors: Bithin Alangot Seshagiri Prabhu Harish Navnit
+Copyright: Wise Earth Technology
+This file is part of the CrisisCommunicator Project.  
+It is licensed under the Peaceful Open Source License.  
+Please see the license terms in PeaceOSL.txt
+"""
 from django.forms import ModelForm
 from django import forms
 

--- a/webapp/refugeecenter/models.py
+++ b/webapp/refugeecenter/models.py
@@ -1,3 +1,11 @@
+"""
+Filename: refugeecenter/models.py
+Authors: Bithin Alangot Seshagiri Prabhu Harish Navnit
+Copyright: Wise Earth Technology
+This file is part of the CrisisCommunicator Project.  
+It is licensed under the Peaceful Open Source License.  
+Please see the license terms in PeaceOSL.txt
+"""
 from django.db import models
 
 from crisis.models import Global, TrackCommunicator

--- a/webapp/refugeecenter/search_indexes.py
+++ b/webapp/refugeecenter/search_indexes.py
@@ -1,31 +1,10 @@
 """
-Redistribution and use of the software accompanying this license in source and 
-binary forms, with or without modification, are permitted provided that the 
-following conditions are met:
-
-    1. Redistributions of source code must retain the above copyright notice, 
-	this list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright 
-	notice, this list of conditions and the following disclaimer in the 
-	documentation and/or other materials provided with the distribution.
-    3. Modifications to the source code must retain the above copyright 
-	notice, this list of conditions, and the following disclaimer, and may 
-	not include further conditions or licensing which go against the spirit 
-	of this license.
-    4. This software may not be used to cause deliberate harm to any 
-	individual, either directly or indirectly, in any form.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER, AUTHORS, OR CONTRIBUTORS BE
-LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE 
-GOODS OR SERVICES; LOSS OF USE, DATA, MONEY, POSSESSIONS, OR LIFE; OR BUSINESS 
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
-IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
-OF SUCH DAMAGE.
+Filename: refugeecenter/search_indexes.py
+Authors: Bithin Alangot Seshagiri Prabhu Harish Navnit
+Copyright: Wise Earth Technology
+This file is part of the CrisisCommunicator Project.  
+It is licensed under the Peaceful Open Source License.  
+Please see the license terms in PeaceOSL.txt
 """
 import datetime
 from haystack import indexes

--- a/webapp/refugeecenter/urls.py
+++ b/webapp/refugeecenter/urls.py
@@ -1,31 +1,10 @@
 """
-Redistribution and use of the software accompanying this license in source and 
-binary forms, with or without modification, are permitted provided that the 
-following conditions are met:
-
-    1. Redistributions of source code must retain the above copyright notice, 
-	this list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright 
-	notice, this list of conditions and the following disclaimer in the 
-	documentation and/or other materials provided with the distribution.
-    3. Modifications to the source code must retain the above copyright 
-	notice, this list of conditions, and the following disclaimer, and may 
-	not include further conditions or licensing which go against the spirit 
-	of this license.
-    4. This software may not be used to cause deliberate harm to any 
-	individual, either directly or indirectly, in any form.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER, AUTHORS, OR CONTRIBUTORS BE
-LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE 
-GOODS OR SERVICES; LOSS OF USE, DATA, MONEY, POSSESSIONS, OR LIFE; OR BUSINESS 
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
-IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
-OF SUCH DAMAGE.
+Filename: refugeecenter/urls.py
+Authors: Bithin Alangot Seshagiri Prabhu Harish Navnit
+Copyright: Wise Earth Technology
+This file is part of the CrisisCommunicator Project.  
+It is licensed under the Peaceful Open Source License.  
+Please see the license terms in PeaceOSL.txt
 """
 from django.conf.urls.defaults import *
 from views import refugee_center, refugee_center_update, refugee_center_list, \

--- a/webapp/refugeecenter/views.py
+++ b/webapp/refugeecenter/views.py
@@ -1,31 +1,10 @@
 """
-Redistribution and use of the software accompanying this license in source and 
-binary forms, with or without modification, are permitted provided that the 
-following conditions are met:
-
-    1. Redistributions of source code must retain the above copyright notice, 
-	this list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright 
-	notice, this list of conditions and the following disclaimer in the 
-	documentation and/or other materials provided with the distribution.
-    3. Modifications to the source code must retain the above copyright 
-	notice, this list of conditions, and the following disclaimer, and may 
-	not include further conditions or licensing which go against the spirit 
-	of this license.
-    4. This software may not be used to cause deliberate harm to any 
-	individual, either directly or indirectly, in any form.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER, AUTHORS, OR CONTRIBUTORS BE
-LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE 
-GOODS OR SERVICES; LOSS OF USE, DATA, MONEY, POSSESSIONS, OR LIFE; OR BUSINESS 
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
-IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
-OF SUCH DAMAGE.
+Filename: refugeecenter/views.py
+Authors: Bithin Alangot Seshagiri Prabhu Harish Navnit
+Copyright: Wise Earth Technology
+This file is part of the CrisisCommunicator Project.  
+It is licensed under the Peaceful Open Source License.  
+Please see the license terms in PeaceOSL.txt
 """
 from django.shortcuts import render_to_response, get_object_or_404
 from django.template import RequestContext

--- a/webapp/resources/forms.py
+++ b/webapp/resources/forms.py
@@ -1,3 +1,11 @@
+"""
+Filename: resources/forms.py
+Authors: Bithin Alangot Seshagiri Prabhu Harish Navnit
+Copyright: Wise Earth Technology
+This file is part of the CrisisCommunicator Project.  
+It is licensed under the Peaceful Open Source License.  
+Please see the license terms in PeaceOSL.txt
+"""
 from django.forms import ModelForm
 from django import forms
 

--- a/webapp/resources/models.py
+++ b/webapp/resources/models.py
@@ -1,3 +1,11 @@
+"""
+Filename: resources/models.py
+Authors: Bithin Alangot Seshagiri Prabhu Harish Navnit
+Copyright: Wise Earth Technology
+This file is part of the CrisisCommunicator Project.  
+It is licensed under the Peaceful Open Source License.  
+Please see the license terms in PeaceOSL.txt
+"""
 from django.db import models
 from refugeecenter.models import RefugeeCenter
 from crisis.models import Global, Comment

--- a/webapp/resources/urls.py
+++ b/webapp/resources/urls.py
@@ -1,31 +1,10 @@
 """
-Redistribution and use of the software accompanying this license in source and 
-binary forms, with or without modification, are permitted provided that the 
-following conditions are met:
-
-    1. Redistributions of source code must retain the above copyright notice, 
-	this list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright 
-	notice, this list of conditions and the following disclaimer in the 
-	documentation and/or other materials provided with the distribution.
-    3. Modifications to the source code must retain the above copyright 
-	notice, this list of conditions, and the following disclaimer, and may 
-	not include further conditions or licensing which go against the spirit 
-	of this license.
-    4. This software may not be used to cause deliberate harm to any 
-	individual, either directly or indirectly, in any form.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER, AUTHORS, OR CONTRIBUTORS BE
-LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE 
-GOODS OR SERVICES; LOSS OF USE, DATA, MONEY, POSSESSIONS, OR LIFE; OR BUSINESS 
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
-IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
-OF SUCH DAMAGE.
+Filename: resources/urls.py
+Authors: Bithin Alangot Seshagiri Prabhu Harish Navnit
+Copyright: Wise Earth Technology
+This file is part of the CrisisCommunicator Project.  
+It is licensed under the Peaceful Open Source License.  
+Please see the license terms in PeaceOSL.txt
 """
 from django.conf.urls.defaults import *
 

--- a/webapp/resources/views.py
+++ b/webapp/resources/views.py
@@ -1,31 +1,10 @@
 """
-Redistribution and use of the software accompanying this license in source and 
-binary forms, with or without modification, are permitted provided that the 
-following conditions are met:
-
-    1. Redistributions of source code must retain the above copyright notice, 
-	this list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright 
-	notice, this list of conditions and the following disclaimer in the 
-	documentation and/or other materials provided with the distribution.
-    3. Modifications to the source code must retain the above copyright 
-	notice, this list of conditions, and the following disclaimer, and may 
-	not include further conditions or licensing which go against the spirit 
-	of this license.
-    4. This software may not be used to cause deliberate harm to any 
-	individual, either directly or indirectly, in any form.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER, AUTHORS, OR CONTRIBUTORS BE
-LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE 
-GOODS OR SERVICES; LOSS OF USE, DATA, MONEY, POSSESSIONS, OR LIFE; OR BUSINESS 
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
-IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
-OF SUCH DAMAGE.
+Filename: resources/views.py
+Authors: Bithin Alangot Seshagiri Prabhu Harish Navnit
+Copyright: Wise Earth Technology
+This file is part of the CrisisCommunicator Project.  
+It is licensed under the Peaceful Open Source License.  
+Please see the license terms in PeaceOSL.txt
 """
 from django.shortcuts import get_object_or_404, render_to_response
 from django.http import HttpResponseRedirect


### PR DESCRIPTION
Added license header in the code files as mentioned in [issue3](https://github.com/WiseEarthTechnology/CrisisCommunicator/issues/3)  in the below format:

``` bash
Filename: <insert filename> 
Authors: <insert authors>
Copyright: Wise Earth Technology
This file is part of the CrisisCommunicator Project.  
It is licensed under the Peaceful Open Source License.  
Please see the license terms in PeaceOSL.txt
```
